### PR TITLE
Acotar la aparición de la splash screen solo al recargar el home

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { AuthContextProvider, FiltersContextProvider } from './context';
+import { AuthContextProvider, FiltersContextProvider} from './context';
 import axiosInterceptor from './interceptor/axiosInterceptor';
 import AppRoutes from './routes';
 import { ToastContainer } from 'react-toastify';
 import './App.css';
 import SplashScreen from './components/SplashScreen/SplashScreen';
+import { LoadingProvider } from './context/LoadingContext';
 
 
 const App = () => {
@@ -27,11 +28,14 @@ const App = () => {
         <FiltersContextProvider>
           <BrowserRouter>
             <ToastContainer />
-            {isLoading ? <SplashScreen /> : <AppRoutes />}
+              <LoadingProvider>
+                <AppRoutes/>
+              </LoadingProvider>
           </BrowserRouter>
         </FiltersContextProvider>
       </AuthContextProvider>
     </div>
   );
 };
+
 export default App;

--- a/src/components/SplashScreen/SplashScreen.jsx
+++ b/src/components/SplashScreen/SplashScreen.jsx
@@ -2,21 +2,22 @@ import React, { useEffect, useState } from 'react';
 import logoInnova from '../../assets/images/logo_innova_yellow.png';
 
 
-const SplashScreen = () => {
+const SplashScreen = ({ onComplete }) => {
     const [showLogo, setShowLogo] = useState(true);
 
     useEffect(() => {
         // Ocultar el logo después de 1.5 segundos
         const timer = setTimeout(() => {
         setShowLogo(false);
+        onComplete(); // Llamada a la función onComplete cuando termine la animación
         }, 2000);
 
         // Limpiar el timer cuando el componente se desmonte
         return () => clearTimeout(timer);
-    }, []);
+    }, [onComplete]);
 
     return (
-        <div className={`flex items-center justify-center h-screen bg-blue-500 ${showLogo ? 'animate-slideUp' : ''}`}>
+        <div className={`fixed top-0 left-0 w-full h-full bg-blue-500 flex items-center justify-center z-50 ${showLogo ? 'animate-slideUp' : 'hidden'}`}>
         {showLogo && (
             <img
             src={logoInnova}

--- a/src/context/LoadingContext.jsx
+++ b/src/context/LoadingContext.jsx
@@ -1,0 +1,16 @@
+// LoadingContext.js
+import React, { createContext, useContext, useState } from 'react';
+
+const LoadingContext = createContext();
+
+export const useLoading = () => useContext(LoadingContext);
+
+export const LoadingProvider = ({ children }) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  return (
+    <LoadingContext.Provider value={{ isLoading, setIsLoading }}>
+      {children}
+    </LoadingContext.Provider>
+  );
+};

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,4 +1,5 @@
-import { Route, Routes } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import Layout from '../layout/Layout';
 import AcercaDe from '../pages/AcercaDe';
 import Admin from '../pages/Admin';
@@ -22,20 +23,37 @@ import AdminAuthorEdit from '../pages/Admin/Authors/Edit';
 import AdminAuthorNew from '../pages/Admin/Authors/New';
 import SplashScreen from '../components/SplashScreen/SplashScreen';
 import ByKeyword from '../pages/ByKeyword/byKeyword';
+import { useLoading } from '../context/LoadingContext'; 
 import EditUserView from '../pages/Admin/EditUser';
 
 const AppRoutes = () => {
+  const { isLoading, setIsLoading } = useLoading(); // Usamos el contexto para acceder a isLoading
+  const [showSplash, setShowSplash] = useState(true);
+  const location = useLocation();
+  const isHome = location.pathname === '/';
+
+  useEffect(() => {
+    setShowSplash(isLoading);
+  }, [isLoading]);
+
+  const handleSplashComplete = () => {
+    setShowSplash(false);
+    setIsLoading(false); // Actualizamos el estado de isLoading cuando se oculta el SplashScreen
+  };
+
+
   return (
     <Routes>
-      <Route
-        exact
-        path="/splash"
-        element={
-          <Layout>
-            <SplashScreen />
-          </Layout>
-        }
-      />
+      {showSplash && isHome && (
+        <Route
+          path="/"
+          element={
+            <Layout>
+              <SplashScreen onComplete={handleSplashComplete} />
+            </Layout>
+          }
+        />
+      )}
       <Route
         exact
         path="/"


### PR DESCRIPTION
Corregí un error en la splash screen. No solo aparecía al cargar el home, sino también al recargar cualquier otra página.